### PR TITLE
Removed Psalm requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
             "email": "joehoyle@gmail.com"
         }
     ],
-    "require": {
-        "vimeo/psalm": "^3.11"
+    "suggest": {
+        "vimeo/psalm": "Psalm is a static analysis tool for finding errors in PHP applications, built on top of PHP Parser."
     },
     "require-dev": {
         "phpunit/phpunit": "^7.2",


### PR DESCRIPTION
While this package was written as a Psalm extension:

- It doesn't strictly require Psalm
- It can be used by other tools (e.g. PHPStan)
- It doesn't need to enforce a particular version of Psalm
- It doesn't need to enforce installing Psalm (especially, but not only when using Phar/Phive)